### PR TITLE
Fix to work even if GNU Bash is installed under "/usr/local/bin" directory.

### DIFF
--- a/eow
+++ b/eow
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 


### PR DESCRIPTION
The following Bash versions didn't work properly and worked with `/usr/local/bin/bash` (this is set in the PATH environment variable).

```bash
$ /bin/bash --version
GNU bash, version 3.2.57(1)-release (x86_64-apple-darwin18)
Copyright (C) 2007 Free Software Foundation, Inc.
```
